### PR TITLE
Update ROOT to 6.36.02

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
     - intel-tbb@2022.0.0
     - nlohmann-json@3.11.3
     - podio@1.3
-    - root@6.34.08 -aqua -opengl
+    - root@6.36.02 -aqua -opengl
     - dd4hep@1.32 +xercesc +edm4hep +hepmc3
     - geomodel@6.15.0 +geomodelg4
     - python@3.13.2


### PR DESCRIPTION
ROOT 6.34 is EOL and superseded by ROOT 6.36.