### PR TITLE
Bump spack package versions

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -8,8 +8,8 @@ spack:
     - nlohmann-json@3.12.0
     - podio@1.7
     - root@6.38.04 -aqua -opengl -cxxmodules
-    - dd4hep@1.35 +xercesc +edm4hep +hepmc3
-    - geomodel@6.24.0 +geomodelg4
+    - dd4hep@1.36 +xercesc +edm4hep +hepmc3
+    - geomodel@6.25.0 +geomodelg4
     - python@3.14
     - py-pybind11 @3.0.2
     - py-pip


### PR DESCRIPTION
This pull request updates the versions of two dependencies in the `spack.yaml` file to keep the project up-to-date with the latest features and fixes.

Dependency version updates:

* Updated the `dd4hep` dependency from version 1.35 to 1.36, retaining all existing build options.
* Updated the `geomodel` dependency from version 6.24.0 to 6.25.0, retaining the `+geomodelg4` build option.