### PR TITLE
Bump spack package versions

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
     - intel-tbb@2023.0.0
     - nlohmann-json@3.12.0
     - podio@1.7
-    - root@6.38.06 -aqua -opengl -cxxmodules
+    - root@6.40.02 -aqua -opengl -cxxmodules
     - dd4hep@1.37 +xercesc +edm4hep +hepmc3
     - geomodel@6.27.0 +geomodelg4
     - python@3.14

--- a/spack.yaml
+++ b/spack.yaml
@@ -49,6 +49,9 @@ spack:
       variants: build_type=Release
     mesa:
       buildable: false
+    xxhash:
+      require:
+      - +pic
 
   concretizer:
     unify: true

--- a/spack_repo/acts/packages/xxhash/package.py
+++ b/spack_repo/acts/packages/xxhash/package.py
@@ -1,0 +1,18 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+from spack_repo.builtin.packages.xxhash.package import Xxhash as XxhashBase
+
+
+# Temporary until https://github.com/spack/spack-packages/pull/5410 lands.
+# xxhash's static libxxhash.a is built without PIC, so ROOT 6.40 fails to link
+# it into libCore.so ("relocation R_X86_64_32S ... recompile with -fPIC").
+class Xxhash(XxhashBase):
+    variant("pic", default=True, description="Enable position-independent code (PIC)")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags" and self.spec.satisfies("+pic"):
+            flags.append(self.compiler.cc_pic_flag)
+        return (flags, None, None)


### PR DESCRIPTION
Automated version bump generated by `check_versions.py`.

Triggered by the scheduled [bump-versions](https://github.com/acts-project/ci-dependencies/actions/workflows/bump_versions.yml) workflow.