### PR TITLE
Add C++23 builds for all configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   build_macos:
-    name: macos ${{ matrix.os }} · ${{ matrix.compiler }}
+    name: macos ${{ matrix.os }} · ${{ matrix.compiler }}${{ matrix.cxxstd == '23' && ' (C++23)' || '' }}
     permissions:
       contents: write
       packages: write
@@ -29,11 +29,18 @@ jobs:
            compiler: "apple-clang@17.0.0"
            default: true
 
+         - os: macos-26
+           xcode: "26.3"
+           compiler: "apple-clang@17.0.0"
+           cxxstd: "23"
+           default: false
+
     uses: ./.github/workflows/build_one.yml
     with:
       os: ${{ matrix.os }}
       xcode: ${{ matrix.xcode }}
       compiler: ${{ matrix.compiler }}
+      cxxstd: ${{ matrix.cxxstd || '20' }}
       default: ${{ matrix.default }}
 
   build_container:
@@ -59,6 +66,13 @@ jobs:
             os: ubuntu-latest
             default: true
 
+          - image: ghcr.io/acts-project/ubuntu2404:87
+            label: ubuntu24.04
+            compiler: gcc@13.3.0
+            os: ubuntu-latest
+            cxxstd: "23"
+            default: false
+
           - image: ghcr.io/acts-project/ubuntu2404_clang22:87
             label: ubuntu24.04-clang22
             compiler: llvm@22.1.7
@@ -69,6 +83,13 @@ jobs:
             label: ubuntu24.04-arm
             compiler: gcc@13.3.0
             os: ubuntu-24.04-arm
+            default: false
+
+          - image: ghcr.io/acts-project/ubuntu2404:87
+            label: ubuntu24.04-arm
+            compiler: gcc@13.3.0
+            os: ubuntu-24.04-arm
+            cxxstd: "23"
             default: false
 
           - image: ghcr.io/acts-project/alma9-base:87
@@ -93,10 +114,25 @@ jobs:
             os: ubuntu-latest
             default: false
 
+          - image: ghcr.io/acts-project/alma10-base:87
+            label: alma10
+            compiler: gcc@15.2.1
+            compiler_path: "/opt/rh/gcc-toolset-15/root"
+            os: ubuntu-latest
+            cxxstd: "23"
+            default: false
+
           - image: ghcr.io/acts-project/ubuntu2604:87
             label: ubuntu26.04
             compiler: gcc@15.2.0
             os: ubuntu-latest
+            default: false
+
+          - image: ghcr.io/acts-project/ubuntu2604:87
+            label: ubuntu26.04
+            compiler: gcc@15.2.0
+            os: ubuntu-latest
+            cxxstd: "23"
             default: false
 
     uses: ./.github/workflows/build_one.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,18 +60,15 @@ jobs:
             os: ubuntu-latest
             default: true
 
+          # No C++23 variant: gcc@13.3.0's -std=c++23 reports the provisional
+          # __cplusplus draft value rather than the final 202302L (fixed in
+          # gcc 14+), which sends dd4hep's OpaqueDataBlock ctor down a code
+          # path that fails to compile with this compiler.
           - image: ghcr.io/acts-project/ubuntu2404:87
             label: ubuntu24.04
             compiler: gcc@13.3.0
             os: ubuntu-latest
             default: true
-
-          - image: ghcr.io/acts-project/ubuntu2404:87
-            label: ubuntu24.04
-            compiler: gcc@13.3.0
-            os: ubuntu-latest
-            cxxstd: "23"
-            default: false
 
           - image: ghcr.io/acts-project/ubuntu2404_clang22:87
             label: ubuntu24.04-clang22
@@ -83,13 +80,6 @@ jobs:
             label: ubuntu24.04-arm
             compiler: gcc@13.3.0
             os: ubuntu-24.04-arm
-            default: false
-
-          - image: ghcr.io/acts-project/ubuntu2404:87
-            label: ubuntu24.04-arm
-            compiler: gcc@13.3.0
-            os: ubuntu-24.04-arm
-            cxxstd: "23"
             default: false
 
           - image: ghcr.io/acts-project/alma9-base:87

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,33 +47,33 @@ jobs:
       matrix:
 
         include:
-          - image: ghcr.io/acts-project/alma9-base:88
+          - image: ghcr.io/acts-project/alma9-base:89
             label: alma9
             compiler: gcc@15.2.1
             compiler_path: "/opt/rh/gcc-toolset-15/root"
             os: ubuntu-latest
             default: true
 
-          - image: ghcr.io/acts-project/ubuntu2404_clang22:88
-            label: ubuntu24.04-clang22
+          - image: ghcr.io/acts-project/ubuntu2604_clang22:89
+            label: ubuntu26.04-clang22
             compiler: llvm@22.1.8
             os: ubuntu-latest
             default: false
 
-          - image: ghcr.io/acts-project/alma10-base:88
+          - image: ghcr.io/acts-project/alma10-base:89
             label: alma10
             compiler: gcc@15.2.1
             compiler_path: "/opt/rh/gcc-toolset-15/root"
             os: ubuntu-latest
             default: false
 
-          - image: ghcr.io/acts-project/ubuntu2604:88
+          - image: ghcr.io/acts-project/ubuntu2604:89
             label: ubuntu26.04
             compiler: gcc@15.2.0
             os: ubuntu-latest
             default: true
 
-          - image: ghcr.io/acts-project/ubuntu2604:88
+          - image: ghcr.io/acts-project/ubuntu2604:89
             label: ubuntu26.04-arm
             compiler: gcc@15.2.0
             os: ubuntu-24.04-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
           - image: ghcr.io/acts-project/ubuntu2404_clang22:88
             label: ubuntu24.04-clang22
-            compiler: llvm@22.1.7
+            compiler: llvm@22.1.8
             os: ubuntu-latest
             default: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   build_macos:
-    name: macos ${{ matrix.os }} · ${{ matrix.compiler }}${{ matrix.cxxstd == '23' && ' (C++23)' || '' }}
+    name: macos ${{ matrix.os }} · ${{ matrix.compiler }}
     permissions:
       contents: write
       packages: write
@@ -29,22 +29,16 @@ jobs:
            compiler: "apple-clang@17.0.0"
            default: true
 
-         - os: macos-26
-           xcode: "26.3"
-           compiler: "apple-clang@17.0.0"
-           cxxstd: "23"
-           default: false
-
     uses: ./.github/workflows/build_one.yml
     with:
       os: ${{ matrix.os }}
       xcode: ${{ matrix.xcode }}
       compiler: ${{ matrix.compiler }}
-      cxxstd: ${{ matrix.cxxstd || '20' }}
+      cxxstd: "23"
       default: ${{ matrix.default }}
 
   build_container:
-    name: ${{ matrix.label }} · ${{ matrix.compiler }}${{ matrix.cxxstd == '23' && ' (C++23)' || '' }}
+    name: ${{ matrix.label }} · ${{ matrix.compiler }}
     permissions:
       contents: write
       packages: write
@@ -53,76 +47,36 @@ jobs:
       matrix:
 
         include:
-          - image: ghcr.io/acts-project/alma9-base:87
+          - image: ghcr.io/acts-project/alma9-base:88
             label: alma9
             compiler: gcc@15.2.1
             compiler_path: "/opt/rh/gcc-toolset-15/root"
             os: ubuntu-latest
             default: true
 
-          # No C++23 variant: gcc@13.3.0's -std=c++23 reports the provisional
-          # __cplusplus draft value rather than the final 202302L (fixed in
-          # gcc 14+), which sends dd4hep's OpaqueDataBlock ctor down a code
-          # path that fails to compile with this compiler.
-          - image: ghcr.io/acts-project/ubuntu2404:87
-            label: ubuntu24.04
-            compiler: gcc@13.3.0
-            os: ubuntu-latest
-            default: true
-
-          - image: ghcr.io/acts-project/ubuntu2404_clang22:87
+          - image: ghcr.io/acts-project/ubuntu2404_clang22:88
             label: ubuntu24.04-clang22
             compiler: llvm@22.1.7
             os: ubuntu-latest
             default: false
 
-          - image: ghcr.io/acts-project/ubuntu2404:87
-            label: ubuntu24.04-arm
-            compiler: gcc@13.3.0
+          - image: ghcr.io/acts-project/alma10-base:88
+            label: alma10
+            compiler: gcc@15.2.1
+            compiler_path: "/opt/rh/gcc-toolset-15/root"
+            os: ubuntu-latest
+            default: false
+
+          - image: ghcr.io/acts-project/ubuntu2604:88
+            label: ubuntu26.04
+            compiler: gcc@15.2.0
+            os: ubuntu-latest
+            default: true
+
+          - image: ghcr.io/acts-project/ubuntu2604:88
+            label: ubuntu26.04-arm
+            compiler: gcc@15.2.0
             os: ubuntu-24.04-arm
-            default: false
-
-          - image: ghcr.io/acts-project/alma9-base:87
-            label: alma9
-            compiler: gcc@15.2.1
-            compiler_path: "/opt/rh/gcc-toolset-15/root"
-            os: ubuntu-latest
-            cxxstd: "23"
-            default: false
-
-          - image: ghcr.io/acts-project/ubuntu2404_clang22:87
-            label: ubuntu24.04-clang22
-            compiler: llvm@22.1.7
-            os: ubuntu-latest
-            cxxstd: "23"
-            default: false
-
-          - image: ghcr.io/acts-project/alma10-base:87
-            label: alma10
-            compiler: gcc@15.2.1
-            compiler_path: "/opt/rh/gcc-toolset-15/root"
-            os: ubuntu-latest
-            default: false
-
-          - image: ghcr.io/acts-project/alma10-base:87
-            label: alma10
-            compiler: gcc@15.2.1
-            compiler_path: "/opt/rh/gcc-toolset-15/root"
-            os: ubuntu-latest
-            cxxstd: "23"
-            default: false
-
-          - image: ghcr.io/acts-project/ubuntu2604:87
-            label: ubuntu26.04
-            compiler: gcc@15.2.0
-            os: ubuntu-latest
-            default: false
-
-          - image: ghcr.io/acts-project/ubuntu2604:87
-            label: ubuntu26.04
-            compiler: gcc@15.2.0
-            os: ubuntu-latest
-            cxxstd: "23"
             default: false
 
     uses: ./.github/workflows/build_one.yml
@@ -131,7 +85,7 @@ jobs:
       image: ${{ matrix.image }}
       compiler: ${{ matrix.compiler }}
       compiler_path: ${{ matrix.compiler_path || '' }}
-      cxxstd: ${{ matrix.cxxstd || '20' }}
+      cxxstd: "23"
       default: ${{ matrix.default }}
 
   lockfile_diff:
@@ -143,10 +97,10 @@ jobs:
       contents: read   # gh release view/download
       actions: read    # download-artifact from this run
     env:
-      # Canonical lockfile to compare: the default ubuntu24.04 x86_64 build,
+      # Canonical lockfile to compare: the default ubuntu26.04 x86_64 build,
       # which matches the published spack-container image. The name is
       # compiler-version independent, so it diffs cleanly across releases.
-      CANONICAL_LOCK: spack_linux-ubuntu24.04-x86_64.lock
+      CANONICAL_LOCK: spack_linux-ubuntu26.04-x86_64.lock
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -201,10 +155,10 @@ jobs:
       contents: write  # gh release edit (write release body)
       actions: read    # download-artifact from this run
     env:
-      # Same canonical lockfile as the PR diff: the default ubuntu24.04 x86_64
+      # Same canonical lockfile as the PR diff: the default ubuntu26.04 x86_64
       # build, whose name is compiler-version independent so it diffs cleanly
       # across releases.
-      CANONICAL_LOCK: spack_linux-ubuntu24.04-x86_64.lock
+      CANONICAL_LOCK: spack_linux-ubuntu26.04-x86_64.lock
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -349,4 +303,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          uv run merge_images.py "$REF_NAME" ".*ubuntu24.04.*gcc.*" --push
+          uv run merge_images.py "$REF_NAME" ".*ubuntu26.04.*gcc.*cxx23" --push

--- a/.github/workflows/build_one.yml
+++ b/.github/workflows/build_one.yml
@@ -25,7 +25,7 @@ on:
       cxxstd:
         required: false
         type: string
-        default: "20"
+        default: "23"
       default:
         required: false
         type: boolean

--- a/local_build.py
+++ b/local_build.py
@@ -95,7 +95,7 @@ def build_table(entries: list[dict], indices: list[int] | None = None) -> Table:
             str(idx),
             e["image"],
             e["compiler"],
-            str(e.get("cxxstd", "20")),
+            str(e.get("cxxstd", "23")),
             "✓" if e.get("default") else "",
         )
     return table
@@ -272,7 +272,7 @@ def _docker_run_base(
         "-e",
         f"COMPILER_PATH={entry.get('compiler_path', '')}",
         "-e",
-        f"CXXSTD={str(entry.get('cxxstd', '20'))}",
+        f"CXXSTD={str(entry.get('cxxstd', '23'))}",
         "-e",
         "GITHUB_ENV=/github_env",
         "-w",
@@ -395,7 +395,7 @@ def execute_build(
         f"\n[bold green]Starting:[/bold green] "
         f"[yellow]{entry['compiler']}[/yellow] · "
         f"[green]{entry['image']}[/green]"
-        f" (C++{entry.get('cxxstd', '20')})\n"
+        f" (C++{entry.get('cxxstd', '23')})\n"
     )
     result = subprocess.run(cmd)
     if result.returncode != 0:
@@ -431,7 +431,7 @@ def entry_searchable(e: dict) -> str:
         [
             e.get("compiler", ""),
             e.get("image", ""),
-            str(e.get("cxxstd", "20")),
+            str(e.get("cxxstd", "23")),
         ]
     ).lower()
 


### PR DESCRIPTION
This pull request updates the CI build configuration and local build scripts to standardize on C++23 as the default C++ standard and to migrate the canonical/default build environment from Ubuntu 24.04 to Ubuntu 26.04. It also updates container image versions and related references throughout the workflow files and scripts.

**CI/CD Workflow and Image Updates:**

* Default C++ standard for all builds is now C++23, replacing C++20 in both `.github/workflows/build.yml`, `.github/workflows/build_one.yml`, and `local_build.py`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R37-R41) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L108-R88) [[3]](diffhunk://#diff-7cee0899a653828c75277daf93e9f14d676c1d5fa64d77557a0846b6f121f840L28-R28) [[4]](diffhunk://#diff-ca69d49f4f54260e0b70137ace9c680a88e058c72676508c1a06f0111c908aefL98-R98) [[5]](diffhunk://#diff-ca69d49f4f54260e0b70137ace9c680a88e058c72676508c1a06f0111c908aefL275-R275) [[6]](diffhunk://#diff-ca69d49f4f54260e0b70137ace9c680a88e058c72676508c1a06f0111c908aefL398-R398) [[7]](diffhunk://#diff-ca69d49f4f54260e0b70137ace9c680a88e058c72676508c1a06f0111c908aefL434-R434)
* Updated container image tags for AlmaLinux 9/10, Ubuntu 24.04/26.04, and related Clang/GCC variants to use the latest versions (e.g., `:88` instead of `:87`).

**Canonical Build and Lockfile Migration:**

* The canonical/default build is now Ubuntu 26.04 x86_64 instead of Ubuntu 24.04, including updates to the referenced lockfile and related environment variables in the workflow. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L120-R103) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L178-R161)
* The build matrix and image merge script are updated to use Ubuntu 26.04 GCC C++23 images as the primary reference for release.

**Build Matrix and Defaults:**

* The build matrix has been cleaned up to remove redundant entries and ensure that Ubuntu 26.04 and C++23 are the new defaults for both x86_64 and ARM builds.

These changes ensure that all builds and local development use C++23 by default and align the CI system with the latest supported Ubuntu release and container images.