### PR TITLE
ci(bump_versions): use default token for checkout, gate PR posting to main

### DIFF
--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ secrets.BUMP_VERSIONS_PAT }}
           persist-credentials: false
 
       - name: Install the latest version of uv
@@ -30,7 +29,7 @@ jobs:
         run: uv run check_versions.py --update
 
       - name: Create or update pull request
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BUMP_VERSIONS_PAT }}


### PR DESCRIPTION
The bump_versions workflow runs on pull_request, but checked out with
secrets.BUMP_VERSIONS_PAT. On Dependabot PRs, Actions secrets are not
exposed (only Dependabot secrets), so the token resolved to empty and
actions/checkout failed with "Input required and not supplied: token".

Drop the token input so checkout uses the default GITHUB_TOKEN, which is
available in all contexts and sufficient for a read-only checkout. The
PAT is only needed by the create-pull-request step, which now also
requires github.ref == main (where the secret lives) in addition to the
existing schedule/workflow_dispatch gate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2v3Sd4Hz2muNCqHiqsPbb