### PR TITLE
ci: Keep one C++20 build, and harden the lockfile diff jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,10 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      # The job runs even when builds fail (`!cancelled()`), so there may be no
+      # lock artifacts at all. A missing diff must not fail the workflow.
       - name: Download lockfiles built in this PR
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: spack_*-locks
@@ -131,12 +134,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag=$(gh release view --json tagName -q .tagName)
+          # No release yet (fresh repo/fork) is a normal state, not an error.
+          tag=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [[ -z "$tag" ]]; then
+            echo "::notice::No published release found; nothing to diff against."
+            exit 0
+          fi
           mkdir -p release-locks
-          gh release download "$tag" \
+          if ! gh release download "$tag" \
             --pattern "$CANONICAL_LOCK" \
-            --dir release-locks
+            --dir release-locks; then
+            echo "::warning::Release $tag has no asset matching $CANONICAL_LOCK"
+          fi
 
       - name: Diff lockfiles into job summary
         env:
@@ -145,14 +155,18 @@ jobs:
           old="release-locks/$CANONICAL_LOCK"
           new="pr-locks/$CANONICAL_LOCK"
           {
-            echo "## Dependency changes vs \`$PREV_TAG\`"
+            echo "## Dependency changes vs \`${PREV_TAG:-(no release)}\`"
             echo
             echo "_Canonical lockfile: \`$CANONICAL_LOCK\`_"
             echo
             if [[ -f "$old" && -f "$new" ]]; then
               uv run diff_lockfiles.py "$old" "$new" --markdown
+            elif [[ ! -f "$new" ]]; then
+              echo "> This PR did not produce \`$CANONICAL_LOCK\` (the canonical build failed or was skipped); no diff available."
+            elif [[ -z "$PREV_TAG" ]]; then
+              echo "> No published release to compare against; skipping diff."
             else
-              echo "> Could not locate both lockfiles (old: \`$old\`, new: \`$new\`); skipping diff."
+              echo "> Release \`$PREV_TAG\` does not contain \`$CANONICAL_LOCK\`; skipping diff."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -178,6 +192,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Download lockfiles built for this tag
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: spack_*-locks
@@ -196,7 +211,9 @@ jobs:
           echo "tag=$prev" >> "$GITHUB_OUTPUT"
           if [[ -n "$prev" ]]; then
             mkdir -p prev-locks
-            gh release download "$prev" --pattern "$CANONICAL_LOCK" --dir prev-locks || true
+            if ! gh release download "$prev" --pattern "$CANONICAL_LOCK" --dir prev-locks; then
+              echo "::warning::Release $prev has no asset matching $CANONICAL_LOCK"
+            fi
           fi
 
       - name: Build dependency diff
@@ -206,16 +223,18 @@ jobs:
           old="prev-locks/$CANONICAL_LOCK"
           new="tag-locks/$CANONICAL_LOCK"
           {
-            echo "## Dependency changes vs \`$PREV_TAG\`"
+            echo "## Dependency changes vs \`${PREV_TAG:-(no previous release)}\`"
             echo
             echo "_Canonical lockfile: \`$CANONICAL_LOCK\`_"
             echo
             if [[ -f "$old" && -f "$new" ]]; then
               uv run diff_lockfiles.py "$old" "$new" --markdown
-            elif [[ -f "$new" ]]; then
-              echo "_No previous release lockfile to compare against._"
-            else
+            elif [[ ! -f "$new" ]]; then
               echo "> Canonical lockfile \`$CANONICAL_LOCK\` not found for this build."
+            elif [[ -z "$PREV_TAG" ]]; then
+              echo "_No previous release to compare against._"
+            else
+              echo "_Release \`$PREV_TAG\` does not contain \`$CANONICAL_LOCK\`; no diff available._"
             fi
           } > dependency-diff.md
           cat dependency-diff.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       default: ${{ matrix.default }}
 
   build_container:
-    name: ${{ matrix.label }} · ${{ matrix.compiler }}
+    name: ${{ matrix.label }} · ${{ matrix.compiler }}${{ matrix.cxxstd == '20' && ' (C++20)' || '' }}
     permissions:
       contents: write
       packages: write
@@ -79,13 +79,23 @@ jobs:
             os: ubuntu-24.04-arm
             default: false
 
+          # Keep one C++20 configuration alive so we notice if the stack stops
+          # building against the older standard. Must stay `default: false` so
+          # it does not overwrite the canonical arch lockfile.
+          - image: ghcr.io/acts-project/ubuntu2604:89
+            label: ubuntu26.04
+            compiler: gcc@15.2.0
+            os: ubuntu-latest
+            cxxstd: "20"
+            default: false
+
     uses: ./.github/workflows/build_one.yml
     with:
       os: ${{ matrix.os }}
       image: ${{ matrix.image }}
       compiler: ${{ matrix.compiler }}
       compiler_path: ${{ matrix.compiler_path || '' }}
-      cxxstd: "23"
+      cxxstd: ${{ matrix.cxxstd || '23' }}
       default: ${{ matrix.default }}
 
   lockfile_diff:


### PR DESCRIPTION
Two independent CI changes.

### Keep one C++20 build

#109 moved every configuration to C++23, which leaves nothing watching whether the stack still builds against C++20. This adds back a single C++20 entry — ubuntu26.04 / `gcc@15.2.0`, x86_64 — as a canary.

Supporting changes it needed:

- `cxxstd` was hardcoded to `"23"` in the `build_one.yml` inputs, so a per-entry `matrix.cxxstd` would have been ignored. It comes from the matrix again, defaulting to 23.
- The standard suffix is back in the job name, inverted to mark the odd one out (`(C++20)`), so the two ubuntu26.04/gcc jobs are distinguishable in the checks list.
- The entry stays `default: false`. A default job also copies its lockfile to the arch-generic `spack_linux-ubuntu26.04-x86_64.lock`, which is the canonical file the lockfile diffs compare against; two defaults on the same arch would clobber each other when the artifacts are merged.

Artifact names already embed `cxx${CXXSTD}` via `TARGET_TRIPLET` (`spack_build.sh:169`), and the container merge filter is pinned to `cxx23`, so neither picks this build up.

### Harden the lockfile diff jobs

`lockfile_diff` and the release diff run under `!cancelled()`, so they also run when the builds failed and produced no lock artifacts, and `gh release view` errors out on a repo with no published release yet. Both are normal states, not workflow failures. The jobs now tolerate a missing artifact download, treat "no release" as empty, warn instead of failing when a release has no matching asset, and report the specific reason in the job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)